### PR TITLE
Remove ephemeral directory after process exit

### DIFF
--- a/src/mount.c
+++ b/src/mount.c
@@ -135,7 +135,7 @@ void mount_add_from_spec(struct mount **mounts, const char *spec) {
 	}
 }
 
-void setup_mount(struct mount *mounts, const char *dest, bool is_ephemeral) {
+void setup_mount(struct mount *mounts, const char *dest, const char *ephemeral_dir) {
 	int rc;
 
 	struct mount *sys_mounts = NULL;
@@ -148,26 +148,21 @@ void setup_mount(struct mount *mounts, const char *dest, bool is_ephemeral) {
 
 	_free_ char *procsys_dir = NULL;
 
-	char template[] = "/tmp/pflask-ephemeral-XXXXXX";
-
 	rc = mount(NULL, "/", NULL, MS_SLAVE | MS_REC, NULL);
 	sys_fail_if(rc < 0, "Error mounting slave /");
 
 	if (dest != NULL) {
-		if (is_ephemeral) {
-			if (!mkdtemp(template))
-				sysf_printf("mkdtemp()");
-
-			rc = mount("tmpfs", template, "tmpfs", 0, NULL);
+		if (ephemeral_dir != NULL) {
+			rc = mount("tmpfs", ephemeral_dir, "tmpfs", 0, NULL);
 			sys_fail_if(rc < 0, "Error mounting tmpfs");
 
-			root_dir = path_prefix_root(template, "root");
+			root_dir = path_prefix_root(ephemeral_dir, "root");
 
 			rc = mkdir(root_dir, 0755);
 			sys_fail_if(rc < 0, "Error creating directory '%s'",
 			                    root_dir);
 
-			work_dir = path_prefix_root(template, "work");
+			work_dir = path_prefix_root(ephemeral_dir, "work");
 
 			rc = mkdir(work_dir, 0755);
 			sys_fail_if(rc < 0, "Error creating directory '%s'",

--- a/src/mount.h
+++ b/src/mount.h
@@ -35,4 +35,4 @@ void mount_add(struct mount **mounts, const char *src, const char *dst,
 
 void mount_add_from_spec(struct mount **mounts, const char *spec);
 
-void setup_mount(struct mount *mounts, const char *dest, bool is_ephemeral);
+void setup_mount(struct mount *mounts, const char *dest, const char *ephemeral_dir);

--- a/src/pflask.c
+++ b/src/pflask.c
@@ -75,6 +75,7 @@ int main(int argc, char *argv[]) {
 	struct cgroup *cgroups = NULL;
 	struct user *users = NULL;
 
+	char ephemeral_dir[] = "/tmp/pflask-ephemeral-XXXXXX";
 	char *master;
 	_close_ int master_fd = -1;
 
@@ -183,6 +184,12 @@ int main(int argc, char *argv[]) {
 
 	sync_init(sync);
 
+	// create ephemeral directory before cloning
+	if (args.ephemeral_flag) {
+		if (!mkdtemp(ephemeral_dir))
+			sysf_printf("mkdtemp()");
+	}
+
 	pid = do_clone(&clone_flags);
 
 	if (!pid) {
@@ -208,7 +215,7 @@ int main(int argc, char *argv[]) {
 			sys_fail_if(rc < 0, "Error setting hostname");
 		}
 
-		setup_mount(mounts, args.chroot_arg, args.ephemeral_flag);
+		setup_mount(mounts, args.chroot_arg, args.ephemeral_flag ? ephemeral_dir : NULL);
 
 		if (args.chroot_given) {
 			setup_nodes(args.chroot_arg);
@@ -312,6 +319,11 @@ int main(int argc, char *argv[]) {
 	sync_close(sync);
 
 	clean_cgroup(cgroups);
+
+	if (args.ephemeral_flag) {
+		rc = rmdir(ephemeral_dir);
+		sys_fail_if(rc != 0, "Error deleting ephemeral directory: %s", ephemeral_dir);
+	}
 
 	return status.si_status;
 }


### PR DESCRIPTION
This PR addresses left-behind empty directories in host `/tmp`.

The template is initialized before cloning, and I check for errors at removing the empty directory (could be still busy in an umount operation, or some process using it for some reason).

Sorry if code quality is not up-to-standards, I am pretty rusty in C/C++.
