### PR TITLE
Add capabilities support

### DIFF
--- a/docs/pflask.rst
+++ b/docs/pflask.rst
@@ -22,6 +22,11 @@ host system and other containers.
 OPTIONS
 -------
 
+.. option:: -b, --caps=<+cap1>,<cap2>,<-cap3>
+
+   Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix).
+   See CAPABILITIES_ for more information.
+
 .. option:: -r, --chroot=<dir>
 
    Change the root directory inside the container.
@@ -215,6 +220,23 @@ Creates a pair of ``veth`` network interfaces called *name_outside* and
 No additional configuration will be applied to them.
 
 Example: ``--netif=veth:veth0:eth0``
+
+CAPABILITIES
+------------
+
+pflask can customize the capabilities set of the container process with the ``--caps`` option.
+The argument of ``--caps`` is a comma-separated list of capability names; each capability can be prefixed by either an optional '+' sign (to require an add operation)
+or a '-' sign (to require drop).
+
+Valid capability names are the same name as defined in <linux/capabilities.h>  with the ``CAP_`` prefix removed.
+The string case does not matter.
+
+The first specified capability name can be the alias 'all' to specify either a full or an empty initial set.
+Container processes will start by default with a full set e.g. ``--caps=all``.
+
+Full set example: ``--caps=all,-chown,-setuid,-setgid`` or equivalently ``--caps=-chown,-setuid,-setgid``
+
+Empty set example: ``--caps=-all,+chown``
 
 AUTHOR
 ------

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -1,0 +1,103 @@
+/*
+ * The process in the flask.
+ *
+ * Copyright (c) 2013, gdm85
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+#include <cap-ng.h>
+
+#include "printf.h"
+#include "util.h"
+
+void setup_capabilities(char *caps) {
+	int rc;
+	capng_act_t cap_action;
+	char *cap, *name;
+	char *remainder = ",";
+
+	// initialize capng state
+	capng_get_caps_process();
+
+	// get first cap
+	cap = strtok(caps, remainder);
+
+	if (!strcasecmp(caps, "+all") || !strcasecmp(caps, "all")) {
+		// nop
+
+		cap = strtok(NULL, remainder);
+	} else if (!strcasecmp(caps, "-all")) {
+		capng_clear(CAPNG_SELECT_BOTH);
+
+		cap = strtok(NULL, remainder);
+	}
+
+	while (cap != NULL) {
+		sys_fail_if(strlen(cap) == 0, "Empty capability name specified");
+
+		if (cap[0] == '+') {
+			cap_action = CAPNG_ADD;
+
+			name = &cap[1];
+		} else if (cap[0] == '-') {
+			cap_action = CAPNG_DROP;
+
+			name = &cap[1];
+		} else {
+			// implicit '+'
+			cap_action = CAPNG_ADD;
+
+			name = cap;
+		}
+
+		if (!strcasecmp(name, "all")) {
+			fail_printf("Alias '%s' is valid only as first capability", cap);
+			return;
+		}
+
+		rc = capng_name_to_capability(name);
+		if (rc == -1) {
+			fail_printf("Invalid capability name: '%s'", name);
+			return;
+		}
+
+		rc = capng_update(cap_action, CAPNG_EFFECTIVE|CAPNG_PERMITTED|CAPNG_INHERITABLE|CAPNG_BOUNDING_SET, rc);
+		if (rc != 0) {
+			fail_printf("Error updating capabilities");
+			return;
+		}
+
+		cap = strtok(NULL, remainder);
+	}
+
+	rc = capng_apply(CAPNG_SELECT_BOTH);
+	if (rc != 0) {
+		fail_printf("Could not apply capabilities");
+		return;
+	}
+}

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -84,21 +84,12 @@ void setup_capabilities(unsigned int caps_given, char **caps) {
 		}
 
 		rc = capng_name_to_capability(name);
-		if (rc == -1) {
-			fail_printf("Invalid capability name: '%s'", name);
-			return;
-		}
+		fail_if(rc == -1, "Invalid capability name: '%s'", name);
 
 		rc = capng_update(cap_action, CAPNG_EFFECTIVE|CAPNG_PERMITTED|CAPNG_INHERITABLE|CAPNG_BOUNDING_SET, rc);
-		if (rc != 0) {
-			fail_printf("Error updating capabilities");
-			return;
-		}
+		fail_if(rc != 0, "Error updating capabilities");
 	}
 
 	rc = capng_apply(CAPNG_SELECT_BOTH);
-	if (rc != 0) {
-		fail_printf("Could not apply capabilities");
-		return;
-	}
+	fail_if(rc != 0, "Could not apply capabilities");
 }

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -1,0 +1,31 @@
+/*
+ * The process in the flask.
+ *
+ * Copyright (c) 2015, gdm85
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+void setup_capabilities(char *caps);

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -28,4 +28,4 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-void setup_capabilities(char *caps);
+void setup_capabilities(unsigned int caps_given, char **caps);

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -28,4 +28,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-void setup_capabilities(unsigned int caps_given, char **caps);
+#include <stdbool.h>
+
+#ifdef HAVE_LIBCAP_NG
+#include <cap-ng.h>
+#endif
+
+struct cap_action {
+#ifdef HAVE_LIBCAP_NG
+	capng_act_t action;
+#endif
+	int capability;
+};
+
+void setup_capabilities(bool clear_caps, size_t total_caps, struct cap_action *caps);

--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -1,6 +1,8 @@
 package "pflask"
 version "0.2"
 
+option "caps"  b "Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)"
+       string default="+all" optional multiple
 option "chroot"    r "Change the root directory inside the container"
        string optional
 option "chdir"     c "Change the current directory inside the container"
@@ -27,8 +29,6 @@ option "setenv"    s "Set additional environment variables"
        string optional multiple
 option "keepenv"   k "Do not clear environment"
        flag off
-option "caps"  b "Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)"
-       string default="+all" optional
 
 option "no-userns"  U "Disable user namespace support"
        flag off

--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -27,6 +27,8 @@ option "setenv"    s "Set additional environment variables"
        string optional multiple
 option "keepenv"   k "Do not clear environment"
        flag off
+option "caps"  b "Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)"
+       string default="+all" optional
 
 option "no-userns"  U "Disable user namespace support"
        flag off

--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -1,5 +1,5 @@
 package "pflask"
-version "0.2"
+version "0.3"
 
 option "caps"  b "Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)"
        string default="+all" optional multiple

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -31,7 +31,7 @@ extern "C" {
 
 #ifndef CMDLINE_PARSER_VERSION
 /** @brief the program version */
-#define CMDLINE_PARSER_VERSION "0.2"
+#define CMDLINE_PARSER_VERSION "0.3"
 #endif
 
 /** @brief Where the command line options are stored */

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -85,6 +85,9 @@ struct gengetopt_args_info
   const char *setenv_help; /**< @brief Set additional environment variables help description.  */
   int keepenv_flag;	/**< @brief Do not clear environment (default=off).  */
   const char *keepenv_help; /**< @brief Do not clear environment help description.  */
+  char * caps_arg;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) (default='+all').  */
+  char * caps_orig;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) original value given at command line.  */
+  const char *caps_help; /**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) help description.  */
   int no_userns_flag;	/**< @brief Disable user namespace support (default=off).  */
   const char *no_userns_help; /**< @brief Disable user namespace support help description.  */
   int no_mountns_flag;	/**< @brief Disable mount namespace support (default=off).  */
@@ -113,6 +116,7 @@ struct gengetopt_args_info
   unsigned int attach_given ;	/**< @brief Whether attach was given.  */
   unsigned int setenv_given ;	/**< @brief Whether setenv was given.  */
   unsigned int keepenv_given ;	/**< @brief Whether keepenv was given.  */
+  unsigned int caps_given ;	/**< @brief Whether caps was given.  */
   unsigned int no_userns_given ;	/**< @brief Whether no-userns was given.  */
   unsigned int no_mountns_given ;	/**< @brief Whether no-mountns was given.  */
   unsigned int no_netns_given ;	/**< @brief Whether no-netns was given.  */

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -39,6 +39,11 @@ struct gengetopt_args_info
 {
   const char *help_help; /**< @brief Print help and exit help description.  */
   const char *version_help; /**< @brief Print version and exit help description.  */
+  char ** caps_arg;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) (default='+all').  */
+  char ** caps_orig;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) original value given at command line.  */
+  unsigned int caps_min; /**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)'s minimum occurreces */
+  unsigned int caps_max; /**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix)'s maximum occurreces */
+  const char *caps_help; /**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) help description.  */
   char * chroot_arg;	/**< @brief Change the root directory inside the container.  */
   char * chroot_orig;	/**< @brief Change the root directory inside the container original value given at command line.  */
   const char *chroot_help; /**< @brief Change the root directory inside the container help description.  */
@@ -85,9 +90,6 @@ struct gengetopt_args_info
   const char *setenv_help; /**< @brief Set additional environment variables help description.  */
   int keepenv_flag;	/**< @brief Do not clear environment (default=off).  */
   const char *keepenv_help; /**< @brief Do not clear environment help description.  */
-  char * caps_arg;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) (default='+all').  */
-  char * caps_orig;	/**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) original value given at command line.  */
-  const char *caps_help; /**< @brief Specify comma-separated capabilities to add ('+' prefix) or drop ('-' prefix) help description.  */
   int no_userns_flag;	/**< @brief Disable user namespace support (default=off).  */
   const char *no_userns_help; /**< @brief Disable user namespace support help description.  */
   int no_mountns_flag;	/**< @brief Disable mount namespace support (default=off).  */
@@ -103,6 +105,7 @@ struct gengetopt_args_info
   
   unsigned int help_given ;	/**< @brief Whether help was given.  */
   unsigned int version_given ;	/**< @brief Whether version was given.  */
+  unsigned int caps_given ;	/**< @brief Whether caps was given.  */
   unsigned int chroot_given ;	/**< @brief Whether chroot was given.  */
   unsigned int chdir_given ;	/**< @brief Whether chdir was given.  */
   unsigned int hostname_given ;	/**< @brief Whether hostname was given.  */
@@ -116,7 +119,6 @@ struct gengetopt_args_info
   unsigned int attach_given ;	/**< @brief Whether attach was given.  */
   unsigned int setenv_given ;	/**< @brief Whether setenv was given.  */
   unsigned int keepenv_given ;	/**< @brief Whether keepenv was given.  */
-  unsigned int caps_given ;	/**< @brief Whether caps was given.  */
   unsigned int no_userns_given ;	/**< @brief Whether no-userns was given.  */
   unsigned int no_mountns_given ;	/**< @brief Whether no-mountns was given.  */
   unsigned int no_netns_given ;	/**< @brief Whether no-netns was given.  */

--- a/src/pflask.c
+++ b/src/pflask.c
@@ -79,10 +79,13 @@ int main(int argc, char *argv[]) {
 	struct cgroup *cgroups = NULL;
 	struct user *users = NULL;
 
-	char *cap, *name;
+	char *cap;
+#ifdef HAVE_LIBCAP_NG
+	char *name;
 	bool clear_caps = false;
 	size_t total_caps = 0;
 	struct cap_action parsed_cap;
+#endif
 
 	char *master;
 	_close_ int master_fd = -1;
@@ -169,10 +172,11 @@ int main(int argc, char *argv[]) {
 			} else if (!strcasecmp(cap, "-all")) {
 #ifndef HAVE_LIBCAP_NG
 				fail_printf("No capabilities support built-in");
-#endif
+#else
 				clear_caps = true;
 
 				continue;
+#endif
 			}
 		}
 

--- a/src/pflask.c
+++ b/src/pflask.c
@@ -63,6 +63,9 @@ static size_t validate_optlist(const char *name, const char *opts);
 static void do_daemonize(void);
 static void do_chroot(const char *dest);
 static pid_t do_clone(int *flags);
+static void memory_cleanup(void);
+
+struct cap_action *caps = NULL;
 
 int main(int argc, char *argv[]) {
 	int rc, sync[2];
@@ -75,6 +78,11 @@ int main(int argc, char *argv[]) {
 	struct netif *netifs = NULL;
 	struct cgroup *cgroups = NULL;
 	struct user *users = NULL;
+
+	char *cap, *name;
+	bool clear_caps = false;
+	size_t total_caps = 0;
+	struct cap_action parsed_cap;
 
 	char *master;
 	_close_ int master_fd = -1;
@@ -147,6 +155,65 @@ int main(int argc, char *argv[]) {
 		user_add_map(&users, 'u', id, host_id, count);
 		user_add_map(&users, 'g', id, host_id, count);
 	}
+
+	for (unsigned int i = 0; i < args.caps_given; i++) {
+		cap = args.caps_arg[i];
+
+		fail_if(strlen(cap) == 0, "Empty capability name specified");
+
+		if (i == 0) {
+			if (!strcasecmp(cap, "+all") || !strcasecmp(cap, "all")) {
+				// nop
+
+				continue;
+			} else if (!strcasecmp(cap, "-all")) {
+#ifndef HAVE_LIBCAP_NG
+				fail_printf("No capabilities support built-in");
+#endif
+				clear_caps = true;
+
+				continue;
+			}
+		}
+
+#ifndef HAVE_LIBCAP_NG
+		fail_printf("No capabilities support built-in");
+#else
+		if (cap[0] == '+') {
+			parsed_cap.action = CAPNG_ADD;
+
+			name = &cap[1];
+		} else if (cap[0] == '-') {
+			parsed_cap.action = CAPNG_DROP;
+
+			name = &cap[1];
+		} else {
+			// implicit '+'
+			parsed_cap.action = CAPNG_ADD;
+
+			name = cap;
+		}
+
+		if (i != 0) {
+			// check for alias after prefix removal
+			if (!strcasecmp(name, "all")) {
+				fail_printf("Alias '%s' is valid only as first capability", cap);
+			}
+		}
+
+		rc = capng_name_to_capability(name);
+		fail_if(rc == -1, "Invalid capability name: '%s'", name);
+
+		parsed_cap.capability = rc;
+
+		// reallocate and copy
+		caps = realloc(caps, ++total_caps);
+		caps[total_caps-1] = parsed_cap;
+#endif
+	}
+
+	// release allocated buffers at exit
+	atexit(memory_cleanup);
 
 	for (unsigned int i = 0; i < args.cgroup_given; i++)
 		cgroup_add(&cgroups, args.cgroup_arg[i]);
@@ -229,7 +296,7 @@ int main(int argc, char *argv[]) {
 		umask(0022);
 
 #if HAVE_LIBCAP_NG
-		setup_capabilities(args.caps_given, args.caps_arg);
+		setup_capabilities(clear_caps, total_caps, caps);
 #endif
 
 		if (args.chdir_given) {
@@ -317,6 +384,12 @@ int main(int argc, char *argv[]) {
 	clean_cgroup(cgroups);
 
 	return status.si_status;
+}
+
+static void memory_cleanup() {
+	if (caps != NULL) {
+		free(caps);
+	}
 }
 
 static size_t validate_optlist(const char *name, const char *opts) {

--- a/src/pflask.c
+++ b/src/pflask.c
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
 		umask(0022);
 
 #if HAVE_LIBCAP_NG
-		setup_capabilities(args.caps_arg);
+		setup_capabilities(args.caps_given, args.caps_arg);
 #endif
 
 		if (args.chdir_given) {

--- a/src/pflask.c
+++ b/src/pflask.c
@@ -44,6 +44,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#include "capabilities.h"
 #include "cmdline.h"
 
 #include "pty.h"
@@ -227,7 +228,9 @@ int main(int argc, char *argv[]) {
 
 		umask(0022);
 
-		/* TODO: drop capabilities */
+#if HAVE_LIBCAP_NG
+		setup_capabilities(args.caps_arg);
+#endif
 
 		if (args.chdir_given) {
 			rc = chdir(args.chdir_arg);

--- a/wscript
+++ b/wscript
@@ -5,7 +5,7 @@ import re
 from waflib import Utils
 
 APPNAME = 'pflask'
-VERSION = '0.2'
+VERSION = '0.3'
 
 _INSTALL_DIRS_LIST = [
 	('bindir',  '${DESTDIR}${PREFIX}/bin',      'binary files'),

--- a/wscript
+++ b/wscript
@@ -71,6 +71,9 @@ def configure(cfg):
 	# libdbus
 	my_check_cfg(cfg, 'dbus', package='dbus-1', mandatory=False)
 
+        # libcap-ng
+        my_check_cfg(cfg, 'libcap-ng', package='libcap-ng', mandatory=False)
+
 	# sphinx
 	cfg.find_program('sphinx-build', mandatory=False)
 
@@ -113,20 +116,21 @@ def build(bld):
 
 	sources = [
 		# sources
-		( 'src/cgroup.c'          ),
-		( 'src/cmdline.c'         ),
-		( 'src/dev.c'             ),
-		( 'src/machine.c', 'dbus' ),
-		( 'src/mount.c'           ),
-		( 'src/netif.c'           ),
-		( 'src/nl.c'              ),
-		( 'src/path.c'            ),
-		( 'src/pflask.c'          ),
-		( 'src/printf.c'          ),
-		( 'src/pty.c'             ),
-		( 'src/sync.c'            ),
-		( 'src/user.c'            ),
-		( 'src/util.c'            ),
+		( 'src/capabilities.c', 'libcap-ng'),
+		( 'src/cgroup.c'                   ),
+		( 'src/cmdline.c'                  ),
+		( 'src/dev.c'                      ),
+		( 'src/machine.c',      'dbus'     ),
+		( 'src/mount.c'                    ),
+		( 'src/netif.c'                    ),
+		( 'src/nl.c'                       ),
+		( 'src/path.c'                     ),
+		( 'src/pflask.c'                   ),
+		( 'src/printf.c'                   ),
+		( 'src/pty.c'                      ),
+		( 'src/sync.c'                     ),
+		( 'src/user.c'                     ),
+		( 'src/util.c'                     ),
 	]
 
 	bld.env.append_value('INCLUDES', ['deps', 'src'])


### PR DESCRIPTION
I have now completed the PR, it allows adding/dropping capabilities through [libcap-ng](https://people.redhat.com/sgrubb/libcap-ng/) :)

The added CLI option is `--caps` and takes a comma-separated argument list like `-all,+chown,+setuid`. The first capability of the list can be an alias like `+all`/`all`, `-all` (the `+` sign can be omitted); I loosely modeled it on this one: docker/docker#6687.

Examples of supported syntax:

```
pflask --caps +all # this would be the default, so it respects current version's behavior
pflask --caps -all,+chown # drop all except chown
pflask --caps -all,chown # same as above
pflask --caps +all,-mknod,-setgid,-setuid # allow all capabilities except mknod,setgid and setuid
pflask --caps all,-mknod,-setgid,-setuid # same as above
pflask --caps -mknod,-setgid,-setuid # same as above
```

Example of usage:

```
# touch test && pflask --caps -all chown 1000.1000 test
chown: changing ownership of ‘test’: Operation not permitted
[✘] Child failed with code '1'
# touch test && pflask --caps -all,+chown chown 1000.1000 test
[✔] Child exited
```
