### PR TITLE
fix doc typo on format for user-map argument

### DIFF
--- a/docs/pflask.rst
+++ b/docs/pflask.rst
@@ -66,7 +66,7 @@ OPTIONS
    as seen in the user namespace of the container, the first userid as seen
    on the host, and a range indicating the number of consecutive ids to map.
 
-   Example: ``--user-map=0:100000,65536``
+   Example: ``--user-map=0:100000:65536``
 
 .. option:: -w, --ephemeral
 


### PR DESCRIPTION
changing the example user-map argument from "0:100000,65536" to "0:100000:65536"
