### PR TITLE
fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/printf.h
+++ b/src/printf.h
@@ -39,7 +39,7 @@
 #define CURSOR_HIDE  "[?25l"
 #define CURSOR_SHOW  "[?25h"
 
-int use_syslog;
+extern int use_syslog;
 
 void ok_printf(const char *fmt, ...);
 void debug_printf(const char *fmt, ...);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: src/util.c.1.o:/build/pflask/build/../src/printf.h:42: multiple definition of
      `use_syslog'; src/cgroup.c.1.o:/build/pflask/build/../src/printf.h:42: first defined here